### PR TITLE
modified dt_case_when to work with double and date types

### DIFF
--- a/R/case_when.R
+++ b/R/case_when.R
@@ -34,7 +34,9 @@ dt_case_when <- function(...){
     switch(class,
            "character" = NA_character_,
            "integer" = NA_integer_,
-           "numeric" = NA_real_)
+           "numeric" = NA_real_,
+           "double" = NA_real_,
+           "Date" = as.Date(NA_real_, "1970-01-01"))
 
   # create fifelse() call
   calls <- call("fifelse", conds[[n]], labels[[n]], eval(na_type))


### PR DESCRIPTION
Hi Tyson,

I have encountered an error when I was creating a new column with `data.table` using `dt_case_when()`.

Minimally reproducible example:
```
library(data.table)
library(tidyfast)

temp <- data.table(pseudo_id = c(1, 2, 3, 4, 5),
                   x = sample(1:5, 5, replace = TRUE))

temp[, y := dt_case_when(pseudo_id == 1 ~ x * 1,
                         pseudo_id == 2 ~ x * 2,
                         pseudo_id == 3 ~ x * 3,
                         pseudo_id == 4 ~ x * 4,
                         pseudo_id == 5 ~ x * 5)]
#> Error in fifelse(pseudo_id == 5, x * 5, NULL): 'yes' is of type double but 'no' is of type NULL. Please make sure that both arguments have the same type.
```

I have added double and date types into the function but I have no clue when it comes to writing tests so I did not include it. I'm willing to write the test up if you can point me to a tutorial/guide for `testthat`.