### PR TITLE
Fix var type issue in dt_unnest

### DIFF
--- a/R/unnest.R
+++ b/R/unnest.R
@@ -45,7 +45,7 @@ dt_unnest.default <- function(dt_, col, ...){
   others_dt <- others_dt[, ..keep]
   others_dt <- lapply(others_dt, rep, times = rows)
 
-  dt_[, list(do.call("cbind", others_dt), rbindlist(eval(col)))]
+  dt_[, list(as.data.table(others_dt), rbindlist(eval(col)))]
 }
 
 

--- a/tests/testthat/test-dt_nest.R
+++ b/tests/testthat/test-dt_nest.R
@@ -88,7 +88,7 @@ test_that("unnest row binds data frames", {
       data.table(x = 1:5),
       data.table(x = 6:10)
   ))
-  expect_equal(dt_unnest(df, data, by = id)$x, 1:10)
+  expect_equal(dt_unnest(df, data)$x, 1:10)
 })
 
 test_that("can unnest mixture of name and unnamed lists of same length", {

--- a/tests/testthat/test-tidyfast.R
+++ b/tests/testthat/test-tidyfast.R
@@ -44,21 +44,21 @@ test_that("dt_unnest works", {
      )
 
   nest_dt <- dt_nest(dt, grp)
-  unnest_dt <- dt_unnest(nest_dt, col = data, by = grp)
+  unnest_dt <- dt_unnest(nest_dt, col = data)
   unnest_vec <- dt_hoist(dt, nested1, nested2)
 
-  expect_equal(dim(dt_unnest(nest_dt, col = data, by = grp)), c(100000,6))
+  expect_equal(dim(dt_unnest(nest_dt, col = data)), c(100000,6))
   expect_equal(nrow(dt_hoist(dt,
                              nested1, nested2)),
                1000000)
 
   d <- as.data.frame(dt)
   nest_d <- as.data.frame(nest_dt)
-  unnest_dt <- dt_unnest(nest_d, col = data, by = grp)
+  unnest_dt <- dt_unnest(nest_d, col = data)
   unnest_vec <- dt_hoist(d,
              nested1, nested2)
 
-  expect_equal(dim(dt_unnest(nest_d, col = data, by = grp)), c(100000,6))
+  expect_equal(dim(dt_unnest(nest_d, col = data)), c(100000,6))
   expect_equal(nrow(dt_hoist(dt,
                              nested1, nested2)),
                1000000)


### PR DESCRIPTION
Closes #14 

Fixes issue with variables all turning to `<char>` due to the use of `cbind()` and `do.call()`. 