### PR TITLE
Improve column_selector()

### DIFF
--- a/R/pivot_longer.R
+++ b/R/pivot_longer.R
@@ -80,12 +80,17 @@ dt_pivot_longer.default <- function(dt_,
 column_selector <- function(dt_, select_vars) {
 
   data_names <- colnames(dt_)
-  data_vars <- setNames(as.list(seq_along(dt_)), data_names)
-  select_index <- unlist(eval(select_vars, data_vars))
 
-  if (any(select_index > 0) && any(select_index < 0))
-    stop("cols must only contain columns to drop OR columns to add, not both")
+  data_vars <- setNames(as.list(seq_along(dt_)), data_names)
+
+  select_index <- unlist(eval(select_vars, data_vars))
+  keep_index <- unique(select_index[select_index > 0])
+  if (length(keep_index) == 0) keep_index <- seq_along(dt_)
+  drop_index <- unique(abs(select_index[select_index < 0]))
+
+  select_index <- setdiff(keep_index, drop_index)
 
   select_vars <- data_names[select_index]
+
   select_vars
 }

--- a/tests/testthat/test-dt_pivot_longer.R
+++ b/tests/testthat/test-dt_pivot_longer.R
@@ -66,11 +66,6 @@ test_that("testing removal of multiple columns", {
   expect_warning(dt_pivot_longer(df, c(-x,-y,-z)))
 })
 
-test_that("stops if dropping and adding cols", {
-  df <- data.table(x = c(1, 2), y = c(2,2))
-  expect_error(dt_pivot_longer(df, c(x,-y)))
-})
-
 test_that("stops if given vector", {
   df <- data.table(x = c(1, 2), y = c(2,2))
   expect_error(dt_pivot_longer(df$x, c(x,-y)))


### PR DESCRIPTION
Update to the `column_selector()` function. This now allows both adding/dropping in `cols` such as `c(x:z, -y)` for `dt_pivot_longer()` and `dt_pivot_wider()`.