### PR TITLE
Pass by= as vector, not string

### DIFF
--- a/R/unnest.R
+++ b/R/unnest.R
@@ -98,7 +98,6 @@ dt_hoist.default <- function(dt_, ...) {
   drop <- v.names[classes == "list" | typeofs == "list"]
   drop <- drop[!drop %in% pasted_dots]
   keep <- keep[!keep %in% pasted_dots]
-  keep <- paste(keep, collapse = ",")
   cols <- substitute(unlist(list(...), recursive = FALSE))
 
   if (length(drop) > 1) {


### PR DESCRIPTION
As part of https://github.com/Rdatatable/data.table/issues/4357