### PR TITLE
use setup-r@v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
 
       - name: Query dependencies
         run: |


### PR DESCRIPTION
otoh this is still way more complicated than lintr's own lint action: 

https://github.com/r-lib/lintr/blob/main/.github/workflows/lint.yaml