### PR TITLE
Remove whitespace after operator""

### DIFF
--- a/inst/include/cpp11/R.hpp
+++ b/inst/include/cpp11/R.hpp
@@ -31,7 +31,7 @@
 namespace cpp11 {
 namespace literals {
 
-constexpr R_xlen_t operator"" _xl(unsigned long long int value) { return value; }
+constexpr R_xlen_t operator""_xl(unsigned long long int value) { return value; }
 
 }  // namespace literals
 }  // namespace cpp11

--- a/inst/include/cpp11/named_arg.hpp
+++ b/inst/include/cpp11/named_arg.hpp
@@ -41,7 +41,7 @@ class named_arg {
 
 namespace literals {
 
-inline named_arg operator"" _nm(const char* name, std::size_t) { return named_arg(name); }
+inline named_arg operator""_nm(const char* name, std::size_t) { return named_arg(name); }
 
 }  // namespace literals
 


### PR DESCRIPTION
The space after "" is deprecated since it creates ambiguity with reserved _-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal

This might start throwing compiler warnings under `clang++-20`.